### PR TITLE
Add documentation generated with mdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+/docs_html

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,23 @@ module.exports = function(grunt) {
             grunt: {
                 files: ['Gruntfile.js'],
                 tasks: ['jshint:grunt']
+            },
+
+            docs: {
+                files: ['docs/**/*.md'],
+                tasks: ['docs']
+            }
+        },
+
+        mdoc: {
+            options: {
+                baseTitle: 'Cane',
+                indexContentPath: 'README.md'
+            },
+            docs: {
+                files: {
+                    'docs_html': 'docs'
+                }
             }
         }
     });
@@ -92,6 +109,19 @@ module.exports = function(grunt) {
     ].forEach(grunt.loadNpmTasks);
 
     grunt.registerTask('default', ['karma:dev', 'watch']);
+    grunt.registerTask('docs', ['mdoc']);
     grunt.registerTask('test', ['jshint', 'karma:test']);
+
+    grunt.registerMultiTask('mdoc', function() {
+        var opts = this.options(),
+            mdoc = require('mdoc');
+
+        this.files.forEach(function(file) {
+            opts.inputDir = file.src[0];
+            opts.outputDir = file.dest;
+
+            mdoc.run(opts);
+        });
+    });
 
 };

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ To run the tests once, simply run `npm test` in the root of the repository. You
 must have Chrome and Firefox installed. It will run JSHint on all the files and
 then launch Chrome and Firefox and run all the tests.
 
+The documentation is generated from the Markdown files in the `docs` directory.
+To generate the docs run `grunt docs`. The docs are also automatically generated
+when you are running `grunt` (or `npm start`) and a file in the `docs` directory
+changes. The generated HTML files are stored in the `docs_html` directory.
+
 
 License
 -------

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,0 +1,32 @@
+# Style
+
+Utilities for managing CSS styles and classes.
+
+All functions that take DOM nodes as an argument can be used with a single DOM
+node, and array of DOM nodes, or a `NodeList`.
+
+
+## addClass(nodes, string)
+
+Adds a CSS class to the nodes.
+
+`string` is a space-separated string that contains the CSS classes to add.
+
+If a class is already specified for the node, it will not add a duplicate class.
+
+
+## css(nodes, object, [value])
+
+Sets the specified CSS properties on the nodes.
+
+`object` can be an object containing the keys and values of the CSS properties
+to change. If it is a string, it is the name of a single CSS property to set to
+the value specified by `value`.
+
+
+## removeClass(nodes, string)
+
+Removes a CSS class from the nodes.
+
+`string` is a space-separated string that contains the CSS classes to remove
+from the nodes.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "grunt-karma": "~0.4.4",
         "grunt-contrib-watch": "~0.4.3",
         "grunt-cli": "~0.1.8",
-        "mout": "~0.5.0"
+        "mout": "~0.5.0",
+        "mdoc": "~0.3.3"
     }
 }


### PR DESCRIPTION
This uses [mdoc](https://github.com/millermedeiros/mdoc) to generate the documentation. Not sure about publishing to a `gh-pages` branch yet, but we can figure that out later.
