### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+    - 0.10
+before_script:
+    - export KARMA_BROWSERS='PhantomJS,Firefox'
+    - export DISPLAY=:99.0
+    - sh -e /etc/init.d/xvfb start

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,7 +58,8 @@ module.exports = function(grunt) {
             test: {
                 configFile: 'karma.config.js',
                 singleRun: true,
-                browsers: ['Chrome', 'Firefox']
+                browsers:
+                    (process.env.KARMA_BROWSERS || "Chrome,Firefox").split(",")
             },
 
             dev: {


### PR DESCRIPTION
This adds the required files for Travis CI support. I have it [working](https://travis-ci.org/conradz/cane) in my fork now. It tests on PhantomJS and Firefox, the only browsers that are allowed for Travis CI.
