### PR TITLE
utils/allNodes recurse into nested lists

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -7,9 +7,10 @@ Collection of general utilities, mostly used by other functions in the library.
 
 Handles enumerating over a list of nodes, or handling a single node.
 
-If `nodes` is not a list of nodes, it will convert it into a single-item array.
-Calls `callback` for each node in `nodes`, passing in the current node as the
-first parameter.
+If `nodes` is a list of nodes, it will call `callback` for each item in the
+list, recursing into nested lists. If `nodes` is a single node, it will call
+`callback` with that node. It will pass the current node as the first parameter
+to `callback`.
 
 
 ## isList(value)

--- a/source/utils/allNodes.js
+++ b/source/utils/allNodes.js
@@ -4,11 +4,15 @@ define([
 ], function(forEach, isList) {
 
     function allNodes(nodes, callback) {
-        if (!isList(nodes)) {
-            nodes = [nodes];
-        }
+        var iterator = function(item) {
+            if (!isList(item)) {
+                callback(item);
+            } else {
+                forEach(item, iterator);
+            }
+        };
 
-        forEach(nodes, callback);
+        iterator(nodes);
     }
 
     return allNodes;

--- a/tests/utils/spec-allNodes.js
+++ b/tests/utils/spec-allNodes.js
@@ -1,0 +1,66 @@
+define(["cane/utils/allNodes"], function(allNodes) {
+
+    describe("utils/allNodes", function() {
+
+        it("should call callback for single node", function() {
+            var node = document.createElement("span"),
+                results = [];
+
+            allNodes(node, function(n) { results.push(n); });
+
+            expect(results).toEqual([node]);
+        });
+
+        it("should call callback for each node in array of nodes", function() {
+            var nodes = [
+                    document.createElement("span"),
+                    document.createElement("span"),
+                    document.createElement("span")
+                ],
+                results = [];
+
+            allNodes(nodes, function(n) { results.push(n); });
+
+            expect(results).toEqual(nodes);
+        });
+
+        it("should call callback for each node in NodeList", function() {
+            var parent = document.createElement("div"),
+                childOne = document.createElement("span"),
+                childTwo = document.createElement("span"),
+                results = [];
+            parent.appendChild(childOne);
+            parent.appendChild(childTwo);
+
+            allNodes(parent.children, function(n) { results.push(n); });
+
+            expect(results).toEqual([childOne, childTwo]);
+        });
+
+        it("should recurse into nested lists", function() {
+            var parent = document.createElement("div"),
+                child = document.createElement("span"),
+                items = [
+                    document.createElement("span"),
+                    parent.children,
+                    [
+                        document.createElement("span"),
+                        document.createElement("span")
+                    ]
+                ],
+                results = [];
+            parent.appendChild(child);
+
+            allNodes(items, function(n) { results.push(n); });
+
+            expect(results).toEqual([
+                items[0],
+                child,
+                items[2][0],
+                items[2][1]
+            ]);
+        });
+
+    });
+
+});


### PR DESCRIPTION
This changes `utils/allNodes` to recurse into nested lists/arrays. This should allow greater flexibility when specifying the nodes. It also adds test coverage for `utils/allNodes`.
