### PR TITLE
Allow arguments object to be considered a list

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -17,8 +17,9 @@ first parameter.
 Returns true if `value` is a list.
 
 A list is defined as an array,
-[NodeList](https://developer.mozilla.org/en-US/docs/Web/API/NodeList), or
-[HTMLCollection](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCollection).
+[NodeList](https://developer.mozilla.org/en-US/docs/Web/API/NodeList),
+[HTMLCollection](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCollection),
+or [arguments object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/arguments).
 
 
 ## isNode(value)

--- a/source/utils/isList.js
+++ b/source/utils/isList.js
@@ -1,16 +1,18 @@
 define([
-    "mout/lang/isArray"
-], function(isArray) {
+    "mout/lang/isArray",
+    "mout/lang/isArguments"
+], function(isArray, isArguments) {
 
     var NodeList = window.NodeList,
         HTMLCollection = window.HTMLCollection;
 
-    function isNodeList(value) {
+    function isList(value) {
         return isArray(value) ||
+            isArguments(value) ||
             value instanceof NodeList ||
             value instanceof HTMLCollection;
     }
 
-    return isNodeList;
+    return isList;
 
 });

--- a/tests/utils/spec-isList.js
+++ b/tests/utils/spec-isList.js
@@ -11,6 +11,10 @@ define(["cane/utils/isList"], function(isList) {
             expect(isList([])).toBe(true);
         });
 
+        it("should return true for arguments", function() {
+            expect(isList(arguments)).toBe(true);
+        });
+
         it("should return false for Node", function() {
             var element = document.createElement("div");
             expect(isList(element)).toBe(false);


### PR DESCRIPTION
This should allow directly passing the `arguments` object to functions like `utils/allNodes` or `dom/fragment`, removing the need for `Array.prototype.slice.call(arguments)` in cases when all arguments are nodes.
