### PR TITLE
Add dom/create

### DIFF
--- a/docs/dom.md
+++ b/docs/dom.md
@@ -10,6 +10,39 @@ Appends all the nodes in `items` to the `parent` node.
 Each `items` argument can be a node or an array of nodes to append to `parent`.
 
 
+## create(tag, [attributes,] [content...])
+
+Creates a DOM element and sets the provided attributes and content.
+
+`tag` specifies the HTML tag name for the element. `attributes` can be an object
+where the key-value pairs specify the attributes to set on the new element.
+`content` can be one or more DOM nodes that are appended to the new element, or
+it can be a string that will be the text content of the element. When a string
+is provided as `content`, it will be treated as text, *not* HTML.
+
+Examples:
+
+```js
+// Element (<div></div>)
+var div = create("div");
+
+// Element (<div id="test"></div>)
+var test = create("div", { "id": "test" });
+
+// Element (<div><div></div><div id="test"></div></div>)
+create("div", div, test);
+
+// Element (<div>Hello World!</div>)
+create("div", "Hello World!");
+
+// Element (<div id="container"><div id="test"></div></div>)
+create("div", { "id": "container" }, test);
+
+// Element (<div class="test">Hello World!</div>)
+create("div", { "class": "test" }, "Hello World!");
+```
+
+
 ## fragment(items...)
 
 Creates a [DocumentFragment](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment)

--- a/source/dom/create.js
+++ b/source/dom/create.js
@@ -1,0 +1,45 @@
+define([
+    "mout/object/forOwn",
+    "../utils/isNode",
+    "../utils/isList",
+    "./fragment"
+], function(forOwn, isNode, isList, fragment) {
+
+    var slice = Array.prototype.slice;
+
+    function setAttribute(value, name) {
+        this.setAttribute(name, value);
+    }
+
+    function create(tagName, attributes) {
+        var el = document.createElement(tagName),
+            contentStart = 2; // Content starts at arguments[2]
+
+        if (attributes) {
+            if (isNode(attributes) ||
+                isList(attributes) ||
+                typeof attributes === "string") {
+                // No attributes specified, start content at arguments[1]
+                contentStart = 1;
+            } else {
+                // Attributes object specified, set attributes on the element
+                forOwn(attributes, setAttribute, el);
+            }
+        }
+
+        var content = arguments[contentStart];
+        if (typeof content === "string") {
+            // Set the text content
+            el.textContent = content;
+        } else {
+            // Append provided DOM nodes
+            content = fragment(slice.call(arguments, contentStart));
+            el.appendChild(content);
+        }
+
+        return el;
+    }
+
+    return create;
+
+});

--- a/tests/dom/spec-create.js
+++ b/tests/dom/spec-create.js
@@ -1,0 +1,73 @@
+define(["cane/dom/create"], function(create) {
+
+    describe("dom/create", function() {
+
+        it("should create element with tag name", function() {
+            var el = create("div");
+
+            expect(el.nodeType).toBe(Node.ELEMENT_NODE);
+            expect(el.tagName).toBe("DIV");
+        });
+
+        it("should set attributes on element", function() {
+            var el = create("div", { "class": "test", "data-test": "value" });
+
+            expect(el.className).toBe("test");
+            expect(el.getAttribute("data-test")).toBe("value");
+        });
+
+        it("should add child nodes", function() {
+            var one = document.createElement("span"),
+                two = document.createElement("span"),
+                el = create("div", one, two);
+
+            var nodes = el.childNodes;
+            expect(nodes.length).toBe(2);
+            expect(nodes[0]).toBe(one);
+            expect(nodes[1]).toBe(two);
+        });
+
+        it("should add array of child nodes", function() {
+            var one = document.createElement("span"),
+                two = document.createElement("span"),
+                three = document.createElement("span"),
+                el = create("div", [one, two], three);
+
+            var nodes = el.childNodes;
+            expect(nodes.length).toBe(3);
+            expect(nodes[0]).toBe(one);
+            expect(nodes[1]).toBe(two);
+            expect(nodes[2]).toBe(three);
+        });
+
+        it("should set attributes and add child nodes", function() {
+            var one = document.createElement("span"),
+                two = document.createElement("span"),
+                el = create("div", { "class": "test" }, one, two);
+
+            expect(el.className).toBe("test");
+
+            var nodes = el.childNodes;
+            expect(nodes.length).toBe(2);
+            expect(nodes[0]).toBe(one);
+            expect(nodes[1]).toBe(two);
+        });
+
+        it("should set text", function() {
+            var text = "test <span>test</span>",
+                el = create("div", text);
+
+            expect(el.textContent).toBe(text);
+        });
+
+        it("should set attributes and text", function() {
+            var text = "test content",
+                el = create("div", { "class": "test" }, text);
+
+            expect(el.className).toBe("test");
+            expect(el.textContent).toBe(text);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Fixes #18.

The arguments (optional attributes object followed by variadic content arguments) are kind of confusing at first, but I think it is the simplest that can be done. This helper function greatly reduces boilerplate code (`setAttribute`, `append`, etc.) when creating DOM nodes.
