### PR TITLE
Add dom/matches

### DIFF
--- a/docs/dom.md
+++ b/docs/dom.md
@@ -53,6 +53,14 @@ DOM nodes or (optionally nested) arrays of DOM nodes. If an argument is an
 array, all DOM nodes in the array will be added to the `DocumentFragment`.
 
 
+## matches(selector, items...)
+
+Returns true if all items match the CSS selector.
+
+If any of the items do not match the selector, it will return false. This uses
+the browser's CSS selector matching, so support for some CSS selectors may vary.
+
+
 ## prepend(parent, items...)
 
 Prepends `items` to the `parent` nodes.

--- a/source/dom/matches.js
+++ b/source/dom/matches.js
@@ -1,0 +1,33 @@
+define([
+    "mout/array/find",
+    "../utils/allNodes"
+], function(find, allNodes) {
+
+    var el = document.createElement("div"),
+        matchesFunc = find([
+            "matches",
+            "matchesSelector",
+            "webkitMatchesSelector",
+            "mozMatchesSelector",
+            "msMatchesSelector",
+            "oMatchesSelector"
+        ], function(n) { return typeof el[n] === "function"; });
+
+    if (!matchesFunc) {
+        return null;
+    }
+
+    var slice = Array.prototype.slice;
+
+    function matches(selector) {
+        var isMatch = true;
+        allNodes(slice.call(arguments, 1), function(element) {
+            isMatch = isMatch && element[matchesFunc](selector);
+        });
+
+        return isMatch;
+    }
+
+    return matches;
+
+});

--- a/tests/dom/spec-matches.js
+++ b/tests/dom/spec-matches.js
@@ -1,0 +1,35 @@
+define(["cane/dom/matches"], function(matches) {
+
+    describe("dom/matches", function() {
+
+        it("should return true if node matches selector", function() {
+            var node = document.createElement("div");
+            node.className = "test";
+
+            expect( matches("div.test", node) ).toBe(true);
+        });
+
+        it("should return false if node does not match selector", function() {
+            var node = document.createElement("div");
+
+            expect( matches(".bar", node) ).toBe(false);
+        });
+
+        it("should return true if all nodes match", function() {
+            var first = document.createElement("div"),
+                second = document.createElement("div");
+
+            expect( matches("div", first, second) ).toBe(true);
+        });
+
+        it("should return false if any of the nodes do not match", function() {
+            var first = document.createElement("div"),
+                second = document.createElement("div");
+            first.className = "foo";
+
+            expect( matches(".foo", first, second) ).toBe(false);
+        });
+
+    });
+
+});


### PR DESCRIPTION
This returns `true` if all items match the CSS selector. If any items do not match the selector, it returns `false`. It checks for the DOM function to use, and can use the vendor-prefixed functions when the standard functions are not available.
