### PR TITLE
dom/createVideo

### DIFF
--- a/docs/dom.md
+++ b/docs/dom.md
@@ -77,6 +77,39 @@ create("div", { "id": "container" }, test);
 create("div", { "class": "test" }, "Hello World!");
 ```
 
+## createVideo([sources], [attributes])
+
+Creates a DOM `video` element and creates `source` child nodes for every source specified.
+
+`sources` can be supplied as an array of strings or a single string. `attributes` is an
+object which key-value pairs are used to set attributes of the `video` element.
+
+
+Examples:
+
+```js
+// Element (<video/>)
+var video = createVideo();
+
+
+// Element
+// <video>
+//   <source src="video.mp4" type="video/mp4"/>
+//   <source src="video.ogg" type="video/ogg"/>
+// </video>
+var video = createVideo(["video.mp4", "video.ogg"]);
+
+// Element
+// <video poster="image.jpg" controls="controls">
+//   <source src="video.mp4" type="video/mp4"/>
+// </video>
+var video = createVideo("video.mp4", { poster: "image.jpg", controls: "controls" });
+
+// Element
+// <video poster="image.jpg" />
+var video = createVideo({ poster: "image.jpg" });
+```
+
 
 ## empty(items...)
 

--- a/source/dom/createVideo.js
+++ b/source/dom/createVideo.js
@@ -1,0 +1,38 @@
+define( [
+    "./create",
+    "mout/array/map",
+    "mout/string/lowerCase",
+    "mout/lang/isString",
+    "mout/lang/isArray"
+], function(create, map, lowerCase, isString, isArray) {
+
+    var types = {
+        mp4: "video/mp4",
+        ogg: "video/ogg",
+        webm: "video/webm"
+    };
+
+    function getType(path) {
+        var extension = lowerCase( path.split(".").pop() );
+        return types[extension] || "";
+    }
+
+    function buildSource(path) {
+        return create("source", { src: path, type: getType(path) });
+    }
+
+    function createVideo(sources, attributes) {
+        if (isString(sources)) {
+            sources = [sources];
+        } else if ( !isArray(sources) ) {
+            attributes = sources || {};
+            sources = [];
+        }
+
+        var children = map(sources, buildSource);
+
+        return create("video", attributes, children);
+    }
+
+    return createVideo;
+});

--- a/tests/dom/spec-createVideo.js
+++ b/tests/dom/spec-createVideo.js
@@ -1,0 +1,68 @@
+define(["cane/dom/createVideo"], function(createVideo) {
+
+    describe("dom/createVideo", function() {
+
+
+        function testSource(element, source, type) {
+            expect(element.getAttribute("src")).to.be(source);
+            expect(element.getAttribute("type")).to.be(type);
+        }
+
+        it("should create empty video element", function() {
+            var el = createVideo();
+
+            expect(el.nodeType).to.be(Node.ELEMENT_NODE);
+            expect(el.tagName).to.be("VIDEO");
+            expect(el.childNodes.length).to.be(0);
+        });
+
+        it("should add source node", function() {
+            var el = createVideo("path/video.mp4");
+
+            expect(el.childNodes.length).to.be(1);
+
+            testSource(el.childNodes[0], "path/video.mp4", "video/mp4");
+        });
+
+        it("should add multiple source nodes", function() {
+            var el = createVideo([
+                "path/video.mp4",
+                "path/video.ogg",
+                "path/video.webm"
+            ]);
+
+            expect(el.childNodes.length).to.be(3);
+
+            testSource(el.childNodes[0], "path/video.mp4", "video/mp4");
+            testSource(el.childNodes[1], "path/video.ogg", "video/ogg");
+            testSource(el.childNodes[2], "path/video.webm", "video/webm");
+        });
+
+        it("should accept attributes as a single parameter", function() {
+            var el = createVideo({
+                controls: "controls",
+                poster: "image.jpg",
+            });
+
+            expect(el.getAttribute("controls")).to.be("controls");
+            expect(el.getAttribute("poster")).to.be("image.jpg");
+        });
+
+        it("should accept attributes as second argument", function() {
+
+            // with a string being first argument
+            var el = createVideo( "video.mp4", { poster: "image.jpg" });
+
+            testSource(el.childNodes[0], "video.mp4", "video/mp4");
+            expect(el.getAttribute("poster")).to.be("image.jpg");
+
+            // with an array being second argument
+            el = createVideo( [ "video.mp4" ], { poster: "image.jpg" });
+
+            testSource(el.childNodes[0], "video.mp4", "video/mp4");
+            expect(el.getAttribute("poster")).to.be("image.jpg");
+        });
+
+    });
+
+});


### PR DESCRIPTION
This is a helper method to create video elements. It takes two optional arguments. The first one being an array of paths or a single path and the second one being an object of attributes for the video element.

``` js
createVideo( [ "video.mp4", "video.ogg" ], { id: "video-player" } );
```

results in

``` html
<video class="video-player">
    <source src="video.mp4" type="video/mp4">
    <source src="video.ogg" type="video/ogg">
</video>
```

What do you think @conradz?
