### PR TITLE
adds optional context to listen and delegate

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -3,7 +3,7 @@
 Utilities for manipulating and observing DOM events.
 
 
-## delegate(root, selector, eventNames, callback)
+## delegate(root, selector, eventNames, callback, [context]):Object
 
 Adds `callback` as an event listener that will listen for events that bubble
 from elements that match `selector`.
@@ -18,6 +18,8 @@ triggered on an element that is a child of `root` and matches the specified CSS
 selector. It will not be called when an event is triggered directly on `root`.
 The first argument to `callback` will be the `Event` object and the context will
 be the child node that matches `selector`.
+
+`context` optionally overrides the context of the callback.
 
 The return value is an object that contains a `.remove` function that when
 called will remove the event listener. You cannot remove the listener with
@@ -35,7 +37,7 @@ delegate(container, "button.action", "click", function() {
 See also: [`listen`](#listen)
 
 
-## listen(nodes, eventNames, callback):Object
+## listen(nodes, eventNames, callback, [context]):Object
 
 Adds `callback` as an event listener to all the nodes for the specified events.
 
@@ -46,6 +48,8 @@ attached to.
 `callback` will be called whenever the event is triggered on any of the provided
 nodes. The first argument to `callback` will be the `Event` object and the
 context will be the node that triggered the event.
+
+`context` optionally overrides the context of the callback.
 
 The return value is an object that contains a `remove` method that will remove
 the listener that was added. You can also use

--- a/source/events/delegate.js
+++ b/source/events/delegate.js
@@ -14,16 +14,16 @@ define(["./listen", "../dom/matches"], function(listen, matches) {
         }
     }
 
-    function listenOn(root, selector, eventName, handler) {
+    function delegate(root, selector, eventName, handler, context) {
         return listen(root, eventName, function(e) {
             var target = getTarget(e, selector, root);
             if (target) {
-                handler.call(target, e);
+                handler.call(context ? context : target, e);
             }
         });
     }
 
-    return listenOn;
+    return delegate;
 
 });
 

--- a/source/events/listen.js
+++ b/source/events/listen.js
@@ -2,12 +2,17 @@ define([
     "../utils/allNodes",
     "./removeListener",
     "mout/lang/isArray",
-    "mout/array/forEach"
-], function(allNodes, removeListener, isArray, forEach) {
+    "mout/array/forEach",
+    "mout/function/bind"
+], function(allNodes, removeListener, isArray, forEach, bind) {
 
-    function listen(nodes, eventNames, callback) {
+    function listen(nodes, eventNames, callback, context) {
         if (!isArray(eventNames)) {
             eventNames = eventNames.split(" ");
+        }
+
+        if (context) {
+            callback = bind(callback, context);
         }
 
         allNodes(nodes, function(node) {

--- a/tests/events/spec-delegate.js
+++ b/tests/events/spec-delegate.js
@@ -94,6 +94,23 @@ define(["cane/events/delegate"], function(delegate) {
             expect(handler.calledTwice).to.be(true);
         });
 
+        it("should call callback in context if specified", function() {
+            var span = document.createElement("span"),
+                el = document.createElement("div"),
+                event = document.createEvent("Event"),
+                callback = sinon.spy(),
+                context = { foo: "bar" };
+            event.initEvent("test", true, true);
+
+            el.appendChild(span);
+            document.body.appendChild(el);
+
+            delegate(el, "span", "test", callback, context);
+            span.dispatchEvent(event);
+
+            expect(callback.calledOn(context)).to.be(true);
+        });
+
     });
 
 });

--- a/tests/events/spec-listen.js
+++ b/tests/events/spec-listen.js
@@ -64,6 +64,19 @@ define(["cane/events/listen"], function(listen) {
             expect(callback.called).to.be(false);
         });
 
+        it("should call callback in context if specified", function() {
+            var context = { a: 1 },
+                el = document.createElement("div"),
+                event = document.createEvent("Event"),
+                callback = sinon.spy();
+            event.initEvent("test", true, true);
+
+            listen(el, "test", callback, context);
+            el.dispatchEvent(event);
+
+            expect(callback.calledOn(context)).to.be(true);
+        });
+
     });
 
 });


### PR DESCRIPTION
I find this to be really useful. I added it to my latest project but would like to put it into `cane` for good. What do you think. 

``` js
listen( element, "click", this.onStart, this );
```

In the sense of making it a consistent api I also added it to `delegate`
