### PR TITLE
adds publish tool for npm folder structure

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,25 @@
+# random files
+
+.tmp*
+.project
+.settings/
+.livereload
+.DS_Store?
+ehthumbs.db
+Icon?
+Thumbs.db
+
+
+# stuff not needed by node
+
+node_modules/
+tests/
+doc_html/
+coverage/
+source/
+server/
+
+bower.json
+.travis.yml
+Gruntfile.js
+karma.conf.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+var fs = require( "fs" );
+
 module.exports = function( grunt ) {
 
     grunt.initConfig( {
@@ -88,18 +90,30 @@ module.exports = function( grunt ) {
                 force: true,
                 recursive: true
             }
+        },
+
+        copy: {
+            npm: {
+                files: [
+                    { expand: true, cwd: "source", src: [ "**" ], dest: "./",  }
+                ]
+            }
+        },
+
+        clean: fs.readdirSync( "source" ),
+
+        shell: {
+            npm: {
+                command: "npm publish"
+            }
         }
     } );
 
-    [
-        "grunt-contrib-jshint",
-        "grunt-contrib-watch",
-        "grunt-karma-coveralls",
-        "grunt-karma"
-    ].forEach(grunt.loadNpmTasks);
+    require( "load-grunt-tasks" )( grunt );
 
     grunt.registerTask( "docs", [ "mdoc" ] );
     grunt.registerTask( "test", [ "jshint", "server", "karma", "coveralls" ] );
+    grunt.registerTask( "publish", [ "copy", "shell", "clean" ] );
 
     grunt.registerTask( "server", function() {
         require( "./server/main" );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cane",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Modular DOM library",
   "contributors": [
     {
@@ -43,10 +43,13 @@
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
     "grunt-cli": "^0.1.13",
+    "grunt-contrib-clean": "^0.7.0",
+    "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-karma": "^0.12.1",
     "grunt-karma-coveralls": "^2.5.4",
+    "grunt-shell": "^1.1.2",
     "karma": "^0.13.15",
     "karma-browserify": "^4.4.0",
     "karma-chrome-launcher": "^0.2.1",
@@ -54,6 +57,7 @@
     "karma-firefox-launcher": "^0.1.7",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-tap": "^1.0.3",
+    "load-grunt-tasks": "^3.3.0",
     "mdoc": "~0.3.4",
     "sinon": "^1.17.2",
     "tape": "^4.2.2"


### PR DESCRIPTION
This PR adds a little grunt util: `grunt publish` which temporarily rewrites the source structure and copies all folders within `source` to the top level, then publishes that to npm, and removes those copies. 

We do that to allow packages to be required like so:

``` js
var getJSON = require( "cane/net/getJSON" );
// instead of
var getJSON = require( "cane/source/net/getJSON" );
```

However, for managing the source, we still keep a `source` folder in the repo. 
